### PR TITLE
fix: remove unsafe snapshot iteration suppressions

### DIFF
--- a/packages/recoil-devtools-log-monitor/src/history.ts
+++ b/packages/recoil-devtools-log-monitor/src/history.ts
@@ -203,9 +203,9 @@ export const useRecoilTransactionsHistory = (values?: RecoilState<any>[]) => {
           );
         }
       } else {
-        // @ts-ignore: For some reason this says that Iterable<RecoilValue<unknown>>
-        // is not iterable.
-        for (const node of snapshot.getNodes_UNSTABLE({ isModified: true })) {
+        for (const node of Array.from(
+          snapshot.getNodes_UNSTABLE({ isModified: true })
+        )) {
           const nextValue = await snapshot.getPromise(node);
           const previousValue = await previousSnapshot.getPromise(node);
 

--- a/packages/recoil-devtools-logger/src/RecoilLogger.tsx
+++ b/packages/recoil-devtools-logger/src/RecoilLogger.tsx
@@ -71,9 +71,9 @@ export const RecoilLogger: FC<RecoilLoggerProps> = ({
           );
         });
       } else {
-        // @ts-ignore: For some reason this says that Iterable<RecoilValue<unknown>>
-        // is not iterable.
-        for (const node of snapshot.getNodes_UNSTABLE({ isModified: true })) {
+        for (const node of Array.from(
+          snapshot.getNodes_UNSTABLE({ isModified: true })
+        )) {
           const previousValue = await previousSnapshot.getPromise(node);
           const nextValue = await snapshot.getPromise(node);
 


### PR DESCRIPTION
Fixes #147

## Summary
- materialize Recoil snapshot nodes with `Array.from` before async iteration
- remove the two `@ts-ignore` suppressions in the log monitor and logger
- preserve the existing async node processing behavior with explicit Iterable handling

## Testing
- `pnpm --filter recoil-devtools-log-monitor typecheck`
- `pnpm --filter recoil-devtools-logger typecheck`
- `pnpm --filter recoil-devtools-log-monitor lint`
- `pnpm --filter recoil-devtools-logger lint`
- `pnpm --filter recoil-devtools-log-monitor test` (1 passed)
- `pnpm --filter recoil-devtools-logger test` (14 passed)
- `pnpm --filter recoil-devtools-log-monitor build`
- `pnpm --filter recoil-devtools-logger build`
- Prettier check on both changed files

No changeset is included because this is a typing-only cleanup with no public API or runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history and logging reliability when tracking modified Recoil nodes.
  * Removed an internal type-handling workaround without changing logged data or update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->