### PR TITLE
fix: replace deprecated substr in brighten

### DIFF
--- a/packages/recoil-devtools-log-monitor/src/helpers.ts
+++ b/packages/recoil-devtools-log-monitor/src/helpers.ts
@@ -25,11 +25,12 @@ export const brighten = (hexColor: string, lightness: number) => {
   const lum = lightness || 0;
 
   let rgb = '#';
-  let c;
   for (let i = 0; i < 3; i++) {
-    c = parseInt(hex.substr(i * 2, 2), 16);
-    c = Math.round(Math.min(Math.max(0, c + c * lum), 255)).toString(16);
-    rgb += ('00' + c).substr(c.length);
+    const channel = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    const brightened = Math.round(
+      Math.min(Math.max(0, channel + channel * lum), 255)
+    ).toString(16);
+    rgb += `00${brightened}`.slice(brightened.length);
   }
   return rgb;
 };

--- a/packages/recoil-devtools-log-monitor/test/helpers.test.ts
+++ b/packages/recoil-devtools-log-monitor/test/helpers.test.ts
@@ -1,0 +1,7 @@
+import { brighten } from '../src/helpers';
+
+describe('brighten', () => {
+  it('lightens each RGB channel', () => {
+    expect(brighten('#808080', 0.2)).toBe('#9a9a9a');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace deprecated `substr` calls in `brighten` with `slice`.
- Add a regression test for RGB lightening.

Fixes #143.

## Test plan

- [x] `pnpm --filter recoil-devtools-log-monitor test`
- [x] `pnpm --filter recoil-devtools-log-monitor lint`
- [x] `pnpm --filter recoil-devtools-log-monitor typecheck`
- [x] `pnpm --filter recoil-devtools-log-monitor build`
- [x] `pnpm exec prettier --check packages/recoil-devtools-log-monitor/src/helpers.ts packages/recoil-devtools-log-monitor/test/helpers.test.ts`
