### PR TITLE
fix(dock): report missing monitor switch key

### DIFF
--- a/packages/recoil-devtools-dock/src/DockMonitor.tsx
+++ b/packages/recoil-devtools-dock/src/DockMonitor.tsx
@@ -116,12 +116,6 @@ const DockMonitor: FC<DockMonitorProps> = (props) => {
     );
   } else if (childrenCount > 1 && !changeMonitorKey) {
     console.error(
-      '<DockMonitor> requires at least one monitor inside. ' +
-        'Why don’t you try <LogMonitor>? You can get it at ' +
-        'https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-log-monitor.'
-    );
-  } else if (childrenCount > 1 && !changeMonitorKey) {
-    console.error(
       'You specified multiple monitors inside <DockMonitor> ' +
         'but did not provide `changeMonitorKey` prop to change them. ' +
         'Try specifying <DockMonitor changeMonitorKey="ctrl-m" /> ' +

--- a/packages/recoil-devtools-dock/test/blah.test.tsx
+++ b/packages/recoil-devtools-dock/test/blah.test.tsx
@@ -1,10 +1,41 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import DockMonitor from '../src/DockMonitor';
 
 describe('Render', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(<div />, div);
     ReactDOM.unmountComponentAtNode(div);
+  });
+});
+
+describe('DockMonitor validation', () => {
+  it('reports the missing monitor switch key for multiple children', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <DockMonitor
+        changeMonitorKey=""
+        showShortcutButton={false}
+        persistState={false}
+      >
+        <div />
+        <div />
+      </DockMonitor>
+    );
+
+    expect(error).toHaveBeenCalledWith(
+      'You specified multiple monitors inside <DockMonitor> ' +
+        'but did not provide `changeMonitorKey` prop to change them. ' +
+        'Try specifying <DockMonitor changeMonitorKey="ctrl-m" /> ' +
+        'and then press Ctrl-M.'
+    );
+    expect(error).not.toHaveBeenCalledWith(
+      '<DockMonitor> requires at least one monitor inside. ' +
+        'Why don’t you try <LogMonitor>? You can get it at ' +
+        'https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-log-monitor.'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Remove the unreachable duplicate `DockMonitor` children check.
- Report the correct `changeMonitorKey` guidance when multiple monitors are provided.
- Add a regression test for the diagnostic.

Fixes #140.

## Test plan

- [x] `pnpm --filter recoil-devtools-dock test`
- [x] `pnpm --filter recoil-devtools-dock lint`
- [x] `pnpm --filter recoil-devtools-dock typecheck`
- [x] `pnpm --filter recoil-devtools-dock build`
- [x] Prettier check for changed files
