### PR TITLE
fix(logger): await selected Recoil values

### DIFF
--- a/.changeset/quiet-logger-transactions.md
+++ b/.changeset/quiet-logger-transactions.md
@@ -1,0 +1,5 @@
+---
+'recoil-devtools-logger': patch
+---
+
+Wait for selected Recoil values before emitting transaction logs.

--- a/packages/recoil-devtools-logger/src/RecoilLogger.tsx
+++ b/packages/recoil-devtools-logger/src/RecoilLogger.tsx
@@ -57,7 +57,7 @@ export const RecoilLogger: FC<RecoilLoggerProps> = ({
       let currentState: StateTransaction = state;
 
       if (values?.length) {
-        values?.forEach(async (value) => {
+        for (const value of values) {
           const previousValue = await previousSnapshot.getPromise(value);
           const nextValue = await snapshot.getPromise(value);
 
@@ -69,7 +69,7 @@ export const RecoilLogger: FC<RecoilLoggerProps> = ({
             previousValue,
             nextValue
           );
-        });
+        }
       } else {
         // @ts-ignore: For some reason this says that Iterable<RecoilValue<unknown>>
         // is not iterable.

--- a/packages/recoil-devtools-logger/test/blah.test.tsx
+++ b/packages/recoil-devtools-logger/test/blah.test.tsx
@@ -1,10 +1,54 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { RecoilRoot, atom, useSetRecoilState } from 'recoil';
+import { RecoilLogger } from '../src/RecoilLogger';
+
+const trackedAtom = atom({
+  key: 'logger-test-atom',
+  default: 'initial',
+});
 
 describe('ensure it renders', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(<div />, div);
     ReactDOM.unmountComponentAtNode(div);
+  });
+});
+
+describe('RecoilLogger', () => {
+  it('waits for selected values before logging a transaction', async () => {
+    const entries: any[] = [];
+
+    const UpdateAtom = () => {
+      const setValue = useSetRecoilState(trackedAtom);
+
+      return <button onClick={() => setValue('updated')}>Update</button>;
+    };
+
+    const { getByRole } = render(
+      <RecoilRoot>
+        <RecoilLogger
+          values={[trackedAtom]}
+          logger={() => (entry) => entries.push(entry)}
+        />
+        <UpdateAtom />
+      </RecoilRoot>
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Update' }));
+
+    await waitFor(() => {
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        prevState: { 'logger-test-atom': 'initial' },
+        nextState: { 'logger-test-atom': 'updated' },
+        action: {
+          description: 'Updated keys: logger-test-atom',
+          'logger-test-atom': 'updated',
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #142.

RecoilLogger used forEach(async ...) when tracking selected values, so it emitted the log entry before the asynchronous snapshot reads populated the payload and state. Replace it with an awaited for...of loop, matching the existing transaction-history implementation.

Added a regression test covering the logged payload, previous state, next state, and updated-key description.

## Validation

- pnpm install --frozen-lockfile
- pnpm --filter recoil-devtools-logger test (15 passed)
- pnpm --filter recoil-devtools-logger lint
- pnpm --filter recoil-devtools-logger typecheck
- pnpm --filter recoil-devtools-logger build
- pnpm exec prettier --check on changed source, test, and changeset files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction logs now wait for selected Recoil values to resolve before being emitted.
  * Improved accuracy of previous-state and next-state data in transaction logs.

* **Tests**
  * Added coverage verifying logged state changes and actions after updating a tracked value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->