### PR TITLE
fix: surface swallowed errors in LogMonitorEntry and history

### DIFF
--- a/packages/recoil-devtools-log-monitor/src/components/LogMonitorEntry.tsx
+++ b/packages/recoil-devtools-log-monitor/src/components/LogMonitorEntry.tsx
@@ -121,7 +121,8 @@ export const LogMonitorEntry: FC<Props> = ({
           />
         );
       } catch (err) {
-        errorText = 'Error selecting state.';
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        errorText = `Error selecting state: ${errorMessage}`;
       }
     }
 
@@ -166,7 +167,7 @@ export const LogMonitorEntry: FC<Props> = ({
   return (
     <div
       style={{
-        opacity: selected ? 0.4 : inFuture ? 0.6 : 1,  
+        opacity: selected ? 0.4 : inFuture ? 0.6 : 1,
         textDecoration: collapsed ? 'line-through' : 'none',
         color: theme.base06,
       }}

--- a/packages/recoil-devtools-log-monitor/src/history.ts
+++ b/packages/recoil-devtools-log-monitor/src/history.ts
@@ -121,8 +121,11 @@ export const useRecoilTransactionsHistory = (values?: RecoilState<any>[]) => {
                 previousValue,
                 nextValue
               );
-            } catch {
-              // Skip atoms that can't be accessed
+            } catch (err) {
+              console.warn(
+                `Failed to capture initial state for node ${node.key}:`,
+                err
+              );
             }
           }
         }
@@ -150,7 +153,7 @@ export const useRecoilTransactionsHistory = (values?: RecoilState<any>[]) => {
           });
         }
       } catch (err) {
-        // Silently ignore errors when capturing initial state
+        console.error('Failed to capture initial state:', err);
       }
     };
 


### PR DESCRIPTION
## Summary

This PR improves error diagnostics by surfacing previously swallowed errors.

### Changes
- Include the original error message in `LogMonitorEntry` instead of displaying a generic message.
- Add diagnostic logging for previously swallowed snapshot errors in `history.ts`.
- Keep the existing behavior unchanged while improving debugging.

Fixes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * State-selection errors now display the underlying error message or value for clearer troubleshooting.
  * Initial-state capture failures now provide warning or error messages instead of failing silently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->