### PR TITLE
test: replace placeholder tests with component smoke tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,14 +7,6 @@ export default tseslint.config(
   {
     ignores: ['**/dist/**', '**/node_modules/**', '**/coverage/**', '**/stories/**'],
   },
-  {
-    files: ['**/test/**', '**/*.test.*'],
-    languageOptions: {
-      parserOptions: {
-        projectService: false,
-      },
-    },
-  },
   ...tseslint.configs.recommended,
   ...tseslint.configs.strict,
   ...tseslint.configs.stylistic,
@@ -61,6 +53,14 @@ export default tseslint.config(
       '@typescript-eslint/no-empty-function': 'off',
       'prefer-const': 'off',
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['**/test/**', '**/*.test.*'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+      },
     },
   },
   prettierConfig,

--- a/packages/recoil-devtools-dock/test/blah.test.tsx
+++ b/packages/recoil-devtools-dock/test/blah.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import * as ReactDOM from 'react-dom';
 import { render } from '@testing-library/react';
-import DockMonitor from '../src/DockMonitor';
+import { DockMonitor } from '../src';
 
 describe('Render', () => {
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<div />, div);
-    ReactDOM.unmountComponentAtNode(div);
+    const { container } = render(
+      <DockMonitor>
+        <div />
+      </DockMonitor>
+    );
+    expect(container).toBeTruthy();
   });
 });
 

--- a/packages/recoil-devtools-log-monitor/test/blah.test.tsx
+++ b/packages/recoil-devtools-log-monitor/test/blah.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import * as ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { LogMonitor } from '../src';
 
 describe('Render', () => {
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<div />, div);
-    ReactDOM.unmountComponentAtNode(div);
+    const { container } = render(
+      <RecoilRoot>
+        <LogMonitor />
+      </RecoilRoot>
+    );
+    expect(container).toBeTruthy();
   });
 });

--- a/packages/recoil-devtools-logger/test/blah.test.tsx
+++ b/packages/recoil-devtools-logger/test/blah.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import * as ReactDOM from 'react-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { RecoilRoot, atom, useSetRecoilState } from 'recoil';
-import { RecoilLogger } from '../src/RecoilLogger';
+import { RecoilLogger } from '../src';
 
 const trackedAtom = atom({
   key: 'logger-test-atom',
@@ -11,9 +10,12 @@ const trackedAtom = atom({
 
 describe('ensure it renders', () => {
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<div />, div);
-    ReactDOM.unmountComponentAtNode(div);
+    const { container } = render(
+      <RecoilRoot>
+        <RecoilLogger />
+      </RecoilRoot>
+    );
+    expect(container).toBeTruthy();
   });
 });
 

--- a/packages/recoil-devtools/test/blah.test.tsx
+++ b/packages/recoil-devtools/test/blah.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import * as ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { RecoilDevtools } from '../src';
 
 describe('ensure it renders', () => {
   it('renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<div />, div);
-    ReactDOM.unmountComponentAtNode(div);
+    const { container } = render(
+      <RecoilRoot>
+        <RecoilDevtools />
+      </RecoilRoot>
+    );
+    expect(container).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Replace legacy placeholder tests using `ReactDOM.render`.
- Add meaningful smoke tests with `@testing-library/react`.
- Render the primary exported component for each package.
- Wrap components with the required providers where necessary.
- Fix the ESLint test-file override ordering so test files are linted correctly.
- Leave production code unchanged.

Fixes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated DevTools component tests to use React Testing Library for rendering.
  * Improved test coverage for rendering DevTools, dock, log monitor, and logger components.
  * Simplified component test setup and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->