### PR TITLE
fix(dock): correct LogMonitor repository link

### DIFF
--- a/.changeset/quiet-docks-link.md
+++ b/.changeset/quiet-docks-link.md
@@ -1,0 +1,5 @@
+---
+'recoil-devtools-dock': patch
+---
+
+Correct the LogMonitor link in DockMonitor validation output.

--- a/packages/recoil-devtools-dock/src/DockMonitor.tsx
+++ b/packages/recoil-devtools-dock/src/DockMonitor.tsx
@@ -112,7 +112,7 @@ const DockMonitor: FC<DockMonitorProps> = (props) => {
     console.error(
       '<DockMonitor> requires at least one monitor inside. ' +
         'Why dont you try <LogMonitor>? You can get it at ' +
-        'https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-log-monitor.'
+        'https://github.com/ulises-jeremias/recoil-devtools/tree/main/packages/recoil-devtools-log-monitor.'
     );
   } else if (childrenCount > 1 && !changeMonitorKey) {
     console.error(

--- a/packages/recoil-devtools-dock/test/blah.test.tsx
+++ b/packages/recoil-devtools-dock/test/blah.test.tsx
@@ -14,6 +14,18 @@ describe('Render', () => {
 });
 
 describe('DockMonitor validation', () => {
+  it('links to the Recoil LogMonitor for missing children', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<DockMonitor>{[]}</DockMonitor>);
+
+    expect(error).toHaveBeenCalledWith(
+      '<DockMonitor> requires at least one monitor inside. ' +
+        'Why dont you try <LogMonitor>? You can get it at ' +
+        'https://github.com/ulises-jeremias/recoil-devtools/tree/main/packages/recoil-devtools-log-monitor.'
+    );
+  });
+
   it('reports the missing monitor switch key for multiple children', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -37,7 +49,7 @@ describe('DockMonitor validation', () => {
     expect(error).not.toHaveBeenCalledWith(
       '<DockMonitor> requires at least one monitor inside. ' +
         'Why don’t you try <LogMonitor>? You can get it at ' +
-        'https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-log-monitor.'
+        'https://github.com/ulises-jeremias/recoil-devtools/tree/main/packages/recoil-devtools-log-monitor.'
     );
   });
 });

--- a/packages/recoil-devtools-dock/test/blah.test.tsx
+++ b/packages/recoil-devtools-dock/test/blah.test.tsx
@@ -48,7 +48,7 @@ describe('DockMonitor validation', () => {
     );
     expect(error).not.toHaveBeenCalledWith(
       '<DockMonitor> requires at least one monitor inside. ' +
-        'Why don’t you try <LogMonitor>? You can get it at ' +
+        'Why dont you try <LogMonitor>? You can get it at ' +
         'https://github.com/ulises-jeremias/recoil-devtools/tree/main/packages/recoil-devtools-log-monitor.'
     );
   });


### PR DESCRIPTION
## Summary

- point the dock monitor's LogMonitor link at the correct repository
- make the zero-child validation case explicit in its test
- add a patch changeset

Fixes #141

## Testing

- Vitest: 3 focused tests passed
- ESLint
- TypeScript typecheck
- Prettier check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the LogMonitor repository link shown in DockMonitor validation errors.
  * Updated related validation messaging to consistently direct users to the correct LogMonitor package.

* **Tests**
  * Added coverage confirming validation errors appear when DockMonitor is rendered without required monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->