### PR TITLE
docs: add Discord community badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ storybook-static/
 # Misc
 .next/
 .awcache/
-recoil-devtools
+/recoil-devtools
 megalinter-reports/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/ulises-jeremias/recoil-devtools/actions/workflows/ci.yml/badge.svg)](https://github.com/ulises-jeremias/recoil-devtools/actions)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 > Developer Tools to power-up [Recoil](https://recoiljs.org/) development workflow.
 

--- a/packages/recoil-devtools-dock/README.md
+++ b/packages/recoil-devtools-dock/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/recoil-devtools-dock.svg)](https://npmjs.com/package/recoil-devtools-dock)
 [![Downloads](https://img.shields.io/npm/dm/recoil-devtools-dock.svg)](https://npmjs.com/package/recoil-devtools-dock)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 A resizable and movable dock for Recoil DevTools, powered by [React Dock](https://github.com/alexkuz/react-dock).
 

--- a/packages/recoil-devtools-log-monitor/README.md
+++ b/packages/recoil-devtools-log-monitor/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/recoil-devtools-log-monitor.svg)](https://npmjs.com/package/recoil-devtools-log-monitor)
 [![Downloads](https://img.shields.io/npm/dm/recoil-devtools-log-monitor.svg)](https://npmjs.com/package/recoil-devtools-log-monitor)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 A log monitor for Recoil DevTools that displays state history with time-travel capability.
 

--- a/packages/recoil-devtools-logger/README.md
+++ b/packages/recoil-devtools-logger/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/recoil-devtools-logger.svg)](https://npmjs.com/package/recoil-devtools-logger)
 [![Downloads](https://img.shields.io/npm/dm/recoil-devtools-logger.svg)](https://npmjs.com/package/recoil-devtools-logger)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 A logging tool for Recoil that prints state changes to the console.
 

--- a/packages/recoil-devtools-themes/README.md
+++ b/packages/recoil-devtools-themes/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/recoil-devtools-themes.svg)](https://npmjs.com/package/recoil-devtools-themes)
 [![Downloads](https://img.shields.io/npm/dm/recoil-devtools-themes.svg)](https://npmjs.com/package/recoil-devtools-themes)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 Color themes for Recoil DevTools. Includes Base16 themes and custom themes.
 

--- a/packages/recoil-devtools/README.md
+++ b/packages/recoil-devtools/README.md
@@ -2,6 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/recoil-devtools.svg)](https://npmjs.com/package/recoil-devtools)
 [![Downloads](https://img.shields.io/npm/dm/recoil-devtools.svg)](https://npmjs.com/package/recoil-devtools)
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
 
 A composited DevTools component that combines [DockMonitor](recoil-devtools-dock) and [LogMonitor](recoil-devtools-log-monitor) in a single component.
 


### PR DESCRIPTION
## Summary
- Add Discord community badge linking to https://discord.gg/dwFTsR7fK2
- Place it with existing README badges across the root and package READMEs
- Fix `.gitignore` to only ignore the root `/recoil-devtools` symlink (not `packages/recoil-devtools`)

## Test plan
- [ ] Confirm badge renders on GitHub README preview
- [ ] Confirm click opens Discord invite
- [ ] Confirm package READMEs still trackable by git/lint-staged

Made with [Cursor](https://cursor.com)