### PR TITLE
fix(demo): pin React 18 so Recoil works on GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,9 @@ storybook-static/
 # Misc
 .next/
 .awcache/
+<<<<<<< HEAD
+=======
+# Accidental nested clone / self-symlink at repo root only
+>>>>>>> fb15598 (chore: scope root-only recoil-devtools gitignore entry)
 /recoil-devtools
 megalinter-reports/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ function App() {
 ## Requirements
 
 - Node.js 18+
-- React 18+
+- React 17 or 18 (**not React 19** — Recoil still depends on React internals removed in 19)
 - Recoil 0.7+
 
 ## Project status

--- a/packages/recoil-devtools-dock/package.json
+++ b/packages/recoil-devtools-dock/package.json
@@ -60,7 +60,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17",
+    "react": ">=17 <19",
     "recoil": ">=0.7.0"
   },
   "dependencies": {
@@ -72,14 +72,14 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/parse-key": "^0.2.2",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.39.5",
     "jsdom": "^29.1.1",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "recoil": "^0.7.7",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/recoil-devtools-log-monitor/package.json
+++ b/packages/recoil-devtools-log-monitor/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17",
+    "react": ">=17 <19",
     "recoil": ">=0.7.0"
   },
   "dependencies": {
@@ -75,14 +75,14 @@
     "@testing-library/react": "^16.3.2",
     "@types/base16": "^1.0.5",
     "@types/lodash-es": "^4.17.12",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.39.5",
     "jsdom": "^29.1.1",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "recoil": "^0.7.7",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/recoil-devtools-logger/package.json
+++ b/packages/recoil-devtools-logger/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17",
+    "react": ">=17 <19",
     "recoil": ">=0.7.0"
   },
   "dependencies": {
@@ -71,14 +71,14 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/deep-diff": "^1.0.5",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.39.5",
     "jsdom": "^29.1.1",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "recoil": "^0.7.7",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/recoil-devtools-themes/package.json
+++ b/packages/recoil-devtools-themes/package.json
@@ -59,7 +59,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17"
+    "react": ">=17 <19"
   },
   "dependencies": {
     "base16": "^1.0.0"

--- a/packages/recoil-devtools/package.json
+++ b/packages/recoil-devtools/package.json
@@ -60,21 +60,21 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17",
+    "react": ">=17 <19",
     "recoil": ">=0.7.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9.39.5",
     "jsdom": "^29.1.1",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "recoil": "^0.7.7",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,16 +55,16 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
+        specifier: ^18.3.31
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(esbuild@0.27.7)(yaml@2.9.0))
@@ -78,14 +78,14 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       recoil:
         specifier: ^0.7.7
-        version: 0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.21)(typescript@6.0.3)(yaml@2.9.0)
@@ -103,14 +103,14 @@ importers:
         version: 0.2.1
       react-dock:
         specifier: ^0.8.0
-        version: 0.8.0(@types/react@19.2.17)(react@19.2.8)
+        version: 0.8.0(@types/react@18.3.31)(react@18.3.1)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^7.0.0
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -118,11 +118,11 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
+        specifier: ^18.3.31
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(esbuild@0.28.1)(yaml@2.9.0))
@@ -136,14 +136,14 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       recoil:
         specifier: ^0.7.7
-        version: 0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.21)(typescript@6.0.3)(yaml@2.9.0)
@@ -164,7 +164,7 @@ importers:
         version: 4.18.1
       react-json-tree:
         specifier: ^0.20.0
-        version: 0.20.0(@types/react@19.2.17)(react@19.2.8)
+        version: 0.20.0(@types/react@18.3.31)(react@18.3.1)
       recoil-devtools-themes:
         specifier: workspace:*
         version: link:../recoil-devtools-themes
@@ -174,7 +174,7 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/base16':
         specifier: ^1.0.5
         version: 1.0.5
@@ -182,11 +182,11 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
+        specifier: ^18.3.31
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(esbuild@0.28.1)(yaml@2.9.0))
@@ -200,14 +200,14 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       recoil:
         specifier: ^0.7.7
-        version: 0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.21)(typescript@6.0.3)(yaml@2.9.0)
@@ -229,16 +229,16 @@ importers:
         version: 7.0.0(@testing-library/dom@10.4.1)
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/deep-diff':
         specifier: ^1.0.5
         version: 1.0.5
       '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
+        specifier: ^18.3.31
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(esbuild@0.28.1)(yaml@2.9.0))
@@ -252,14 +252,14 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       recoil:
         specifier: ^0.7.7
-        version: 0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.21)(typescript@6.0.3)(yaml@2.9.0)
@@ -276,8 +276,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       react:
-        specifier: '>=17'
-        version: 19.2.7
+        specifier: '>=17 <19'
+        version: 18.3.1
     devDependencies:
       '@types/base16':
         specifier: ^1.0.5
@@ -301,14 +301,14 @@ importers:
   recoil-devtools-demo:
     dependencies:
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: ^18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       recoil:
         specifier: ^0.7.7
-        version: 0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recoil-devtools:
         specifier: workspace:*
         version: link:../packages/recoil-devtools
@@ -326,11 +326,11 @@ importers:
         version: link:../packages/recoil-devtools-themes
     devDependencies:
       '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
+        specifier: ^18.3.31
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(esbuild@0.28.1)(yaml@2.9.0))
@@ -1310,16 +1310,13 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': ^18.0.0
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
-
-  '@types/react@19.2.17':
-    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -2652,10 +2649,10 @@ packages:
       '@types/react': ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-dom@19.2.8:
-    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^19.2.8
+      react: ^18.3.1
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2669,12 +2666,8 @@ packages:
       '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
-    engines: {node: '>=0.10.0'}
-
-  react@19.2.8:
-    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -2762,8 +2755,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3949,15 +3942,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
@@ -4015,17 +4008,13 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
-      '@types/react': 19.2.17
+      '@types/react': 18.3.31
 
   '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
-  '@types/react@19.2.17':
-    dependencies:
       csstype: 3.2.3
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
@@ -5539,32 +5528,33 @@ snapshots:
       csstype: 3.2.3
       lodash-es: 4.18.1
 
-  react-dock@0.8.0(@types/react@19.2.17)(react@19.2.8):
+  react-dock@0.8.0(@types/react@18.3.31)(react@18.3.1):
     dependencies:
       '@types/lodash-es': 4.17.12
-      '@types/react': 19.2.17
+      '@types/react': 18.3.31
       lodash-es: 4.18.1
-      react: 19.2.8
+      react: 18.3.1
 
-  react-dom@19.2.8(react@19.2.8):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
-      react: 19.2.8
-      scheduler: 0.27.0
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
-  react-json-tree@0.20.0(@types/react@19.2.17)(react@19.2.8):
+  react-json-tree@0.20.0(@types/react@18.3.31)(react@18.3.1):
     dependencies:
       '@types/lodash': 4.17.24
-      '@types/react': 19.2.17
-      react: 19.2.8
+      '@types/react': 18.3.31
+      react: 18.3.1
       react-base16-styling: 0.10.0
 
-  react@19.2.7: {}
-
-  react@19.2.8: {}
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -5575,12 +5565,12 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  recoil@0.7.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  recoil@0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       hamt_plus: 1.0.2
-      react: 19.2.8
+      react: 18.3.1
     optionalDependencies:
-      react-dom: 19.2.8(react@19.2.8)
+      react-dom: 18.3.1(react@18.3.1)
 
   redent@3.0.0:
     dependencies:
@@ -5705,7 +5695,9 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.27.0: {}
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   semver@6.3.1: {}
 

--- a/recoil-devtools-demo/package.json
+++ b/recoil-devtools-demo/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint src --ext ts,tsx"
   },
   "dependencies": {
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "recoil": "^0.7.7",
     "recoil-devtools": "workspace:*",
     "recoil-devtools-dock": "workspace:*",
@@ -20,8 +20,8 @@
     "recoil-devtools-themes": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^6.0.3",
     "vite": "^8.1.4"

--- a/recoil-devtools-demo/vite.config.ts
+++ b/recoil-devtools-demo/vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: '/recoil-devtools/',
   plugins: [react()],
+  resolve: {
+    // Recoil + monitors must share one React instance.
+    dedupe: ['react', 'react-dom'],
+  },
   server: {
     port: 3000,
     open: true,


### PR DESCRIPTION
## Summary
- Revert demo + package React pins from 19 → **18.3.x** (Recoil is incompatible with React 19).
- Narrow peer range to `>=17 <19`.
- Dedupe `react`/`react-dom` in the Vite demo config.
- Document the React 19 ceiling in README Requirements.
- Scope `.gitignore` `/recoil-devtools` to repo root so `packages/recoil-devtools` is not ignored by lint-staged.

## Why
Live demo error:
`Uncaught TypeError: ...__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED is undefined`
— known Recoil + React 19 break (facebookexperimental/Recoil#2318).

## Test plan
- [x] `pnpm build` succeeds
- [x] Bundled React reports `18.3.1` and exports `__SECRET_INTERNALS...`
- [ ] After merge, GH Pages redeploys and https://ulises-jeremias.github.io/recoil-devtools/ loads without console errors

Made with [Cursor](https://cursor.com)