### PR TITLE
test(logger): cover formatting and error handling

### DIFF
--- a/packages/recoil-devtools-logger/test/blah.test.tsx
+++ b/packages/recoil-devtools-logger/test/blah.test.tsx
@@ -3,6 +3,10 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import { RecoilRoot, atom, useSetRecoilState } from 'recoil';
 import { RecoilLogger } from '../src';
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 const trackedAtom = atom({
   key: 'logger-test-atom',
   default: 'initial',
@@ -51,6 +55,42 @@ describe('RecoilLogger', () => {
           'logger-test-atom': 'updated',
         },
       });
+    });
+  });
+
+  it('logs selected state changes through the default console logger', async () => {
+    const group = vi.spyOn(console, 'group').mockImplementation(() => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const groupEnd = vi.spyOn(console, 'groupEnd').mockImplementation(() => {});
+
+    const UpdateAtom = () => {
+      const setValue = useSetRecoilState(trackedAtom);
+
+      return <button onClick={() => setValue('updated')}>Update</button>;
+    };
+
+    const { getByRole } = render(
+      <RecoilRoot>
+        <RecoilLogger values={[trackedAtom]} />
+        <UpdateAtom />
+      </RecoilRoot>
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Update' }));
+
+    await waitFor(() => {
+      expect(group).toHaveBeenCalledOnce();
+      expect(log).toHaveBeenCalledWith(
+        '%c prev state',
+        'color: #9E9E9E; font-weight: bold',
+        { 'logger-test-atom': 'initial' }
+      );
+      expect(log).toHaveBeenCalledWith(
+        '%c next state',
+        'color: #4CAF50; font-weight: bold',
+        { 'logger-test-atom': 'updated' }
+      );
+      expect(groupEnd).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/recoil-devtools-logger/test/logger.test.ts
+++ b/packages/recoil-devtools-logger/test/logger.test.ts
@@ -1,0 +1,92 @@
+import { createLogger } from '../src/logger';
+
+const createMockConsole = () => ({
+  log: vi.fn(),
+  group: vi.fn(),
+  groupCollapsed: vi.fn(),
+  groupEnd: vi.fn(),
+});
+
+describe('createLogger', () => {
+  it('prints state changes with the default formatting and grouping', () => {
+    const console = createMockConsole();
+    const next = vi.fn().mockReturnValue('next result');
+    const action = { description: 'Increment' };
+
+    const result = createLogger({ logger: console })(next)({
+      prevState: { count: 0 },
+      nextState: { count: 1 },
+      action,
+    });
+
+    expect(result).toBe('next result');
+    expect(next).toHaveBeenCalledWith(action);
+    expect(console.group).toHaveBeenCalledOnce();
+    expect(console.group.mock.calls[0][0]).toMatch(
+      /^%c action %cIncrement %c@\d{2}:\d{2}:\d{2}\.\d{3} %c\(in \d+\.\d{2} ms\)$/
+    );
+    expect(console.group.mock.calls[0].slice(1)).toEqual([
+      'color: gray; font-weight: lighter;',
+      'color: inherit;',
+      'color: gray; font-weight: lighter;',
+      'color: gray; font-weight: lighter;',
+    ]);
+    expect(console.log.mock.calls).toEqual([
+      ['%c prev state', 'color: #9E9E9E; font-weight: bold', { count: 0 }],
+      ['%c action    ', 'color: #03A9F4; font-weight: bold', action],
+      ['%c next state', 'color: #4CAF50; font-weight: bold', { count: 1 }],
+    ]);
+    expect(console.groupCollapsed).not.toHaveBeenCalled();
+    expect(console.groupEnd).toHaveBeenCalledOnce();
+  });
+
+  it('uses a collapsed console group when configured', () => {
+    const console = createMockConsole();
+
+    createLogger({ logger: console, collapsed: true })(() => undefined)({
+      prevState: 'before',
+      nextState: 'after',
+      action: { description: 'Update' },
+    });
+
+    expect(console.group).not.toHaveBeenCalled();
+    expect(console.groupCollapsed).toHaveBeenCalledOnce();
+    expect(console.groupCollapsed.mock.calls[0][0]).toMatch(
+      /^%c action %cUpdate /
+    );
+    expect(console.groupEnd).toHaveBeenCalledOnce();
+  });
+
+  it('captures, transforms, prints, and rethrows errors from the next handler', () => {
+    const console = createMockConsole();
+    const originalError = new Error('original error');
+    const transformedError = new Error('transformed error');
+    const errorTransformer = vi.fn().mockReturnValue(transformedError);
+    const next = vi.fn(() => {
+      throw originalError;
+    });
+    const action = { description: 'Fail' };
+
+    const log = createLogger({
+      logger: console,
+      logErrors: true,
+      errorTransformer,
+    })(next);
+
+    expect(() =>
+      log({
+        prevState: { status: 'ready' },
+        nextState: { status: 'failed' },
+        action,
+      })
+    ).toThrow(transformedError);
+    expect(errorTransformer).toHaveBeenCalledOnce();
+    expect(errorTransformer).toHaveBeenCalledWith(originalError);
+    expect(console.log).toHaveBeenCalledWith(
+      '%c error     ',
+      'color: #F20404; font-weight: bold;',
+      transformedError
+    );
+    expect(console.groupEnd).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- retain and extend component coverage for rendering, transaction observation, and the default console logger path
- cover the default colored action header and prev/action/next-state console output
- verify expanded and collapsed console grouping
- verify logErrors captures, transforms, prints, and rethrows handler failures

## Issue coverage

- render without crashing: existing RecoilLogger render test
- log state changes: existing injected-logger transaction test plus a new default-console integration test
- format output: new createLogger formatting and grouping tests
- handle errors: new transformed-error logging and rethrow test

Closes #134

## Testing

- pnpm --filter recoil-devtools-logger test — 4 files, 19 tests passed
- pnpm --filter recoil-devtools-logger lint
- pnpm --filter recoil-devtools-logger typecheck
- pnpm --filter recoil-devtools-logger build
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- focused Prettier and ESLint checks
- pre-commit Prettier and ESLint hooks
- git diff --check

No changeset is included because this is test-only and has no user-visible behavior change.