### PR TITLE
fix: widen React peer range to include React 19

### DIFF
--- a/.changeset/react-19-peer-range.md
+++ b/.changeset/react-19-peer-range.md
@@ -1,0 +1,9 @@
+---
+'recoil-devtools': patch
+'recoil-devtools-dock': patch
+'recoil-devtools-log-monitor': patch
+'recoil-devtools-logger': patch
+'recoil-devtools-themes': patch
+---
+
+Widen React peer range to `>=17 <20` to allow React 19. Verified with a production Vite build of RecoilRoot + atom + useRecoilState on React 19.2 with recoil 0.7.7 (no runtime break observed at build level).

--- a/packages/recoil-devtools-dock/package.json
+++ b/packages/recoil-devtools-dock/package.json
@@ -60,7 +60,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17 <19",
+    "react": ">=17 <20",
     "recoil": ">=0.7.0"
   },
   "dependencies": {

--- a/packages/recoil-devtools-log-monitor/package.json
+++ b/packages/recoil-devtools-log-monitor/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17 <19",
+    "react": ">=17 <20",
     "recoil": ">=0.7.0"
   },
   "dependencies": {

--- a/packages/recoil-devtools-logger/package.json
+++ b/packages/recoil-devtools-logger/package.json
@@ -61,7 +61,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17 <19",
+    "react": ">=17 <20",
     "recoil": ">=0.7.0"
   },
   "dependencies": {

--- a/packages/recoil-devtools-themes/package.json
+++ b/packages/recoil-devtools-themes/package.json
@@ -59,7 +59,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17 <19"
+    "react": ">=17 <20"
   },
   "dependencies": {
     "base16": "^1.0.0"

--- a/packages/recoil-devtools/package.json
+++ b/packages/recoil-devtools/package.json
@@ -60,7 +60,7 @@
     "clean": "rm -rf dist coverage"
   },
   "peerDependencies": {
-    "react": ">=17 <19",
+    "react": ">=17 <20",
     "recoil": ">=0.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,7 +276,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       react:
-        specifier: '>=17 <19'
+        specifier: '>=17 <20'
         version: 18.3.1
     devDependencies:
       '@types/base16':
@@ -3695,7 +3695,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(esbuild@0.27.7)(yaml@2.9.0))
+      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(esbuild@0.28.1)(yaml@2.9.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -3878,7 +3878,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(esbuild@0.27.7)(yaml@2.9.0))
+      vitest: 4.1.11(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.2.2(esbuild@0.28.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.11':
     dependencies:


### PR DESCRIPTION
> AI-assisted PR opened as `@ulises-jeremias` by [agent-toolkit](https://github.com/ulises-jeremias/agent-toolkit) (manual run).

## Why
`recoil-devtools* 1.2.3` declares peer `react >=17 <19`, so any React 19 project (e.g. CNA React 19 templates via the `react-recoil` extension) fails with ERESOLVE. Reproduced locally: `npm install recoil-devtools@1.2.3` on React 19.2 errors; `recoil@0.7.7` alone installs fine.

## Evidence it is safe
Built a production Vite bundle (`RecoilRoot` + `atom` + `useRecoilState`) on React 19.2 + recoil 0.7.7 + these packages installed with `--legacy-peer-deps`: build succeeds. `react-dock` (dock dep) already allows React 19. Full runtime QA still recommended before release.

## Change
- `react: >=17 <19` -> `>=17 <20` in all 5 packages
- Changeset (patch) included so the release flow picks it up

## Follow-up (not in this PR)
After 1.2.4 ships: bump the CNA `react-recoil` extension pins and drop its temporary `.npmrc` workaround (added in Create-Node-App/cna-templates#412).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Recoil DevTools packages now support React 19, while retaining compatibility with React 17 and 18.
  - Supported React versions now range from 17 through 19.

- **Verification**
  - Compatibility was confirmed with a production build using React 19.2 and Recoil 0.7.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->