### PR TITLE
fix(dock): match keyboard shortcuts via event.key instead of keyCode

### DIFF
--- a/.changeset/dock-monitor-event-key.md
+++ b/.changeset/dock-monitor-event-key.md
@@ -1,0 +1,5 @@
+---
+'recoil-devtools-dock': patch
+---
+
+Fix `DockMonitor` keyboard shortcut matching to use the modern `KeyboardEvent.key` value instead of the deprecated `keyCode`/`which` properties, so non-alphabetic shortcuts (e.g. `ctrl-enter`, `ctrl-space`) work correctly.

--- a/packages/recoil-devtools-dock/src/DockMonitor.tsx
+++ b/packages/recoil-devtools-dock/src/DockMonitor.tsx
@@ -128,10 +128,14 @@ const DockMonitor: FC<DockMonitorProps> = (props) => {
       return false;
     }
 
-    const charCode = event.keyCode || event.which;
-    const char = String.fromCharCode(charCode);
+    // Use the modern `KeyboardEvent.key` value instead of the deprecated
+    // `keyCode`/`which` properties, which are incorrect for non-alphabetic
+    // keys. `parse-key` names (e.g. "space") are lowercase words while
+    // `event.key` holds the produced character (e.g. " "), so normalize
+    // the space character before comparing case-insensitively.
+    const pressedKey = event.key === ' ' ? 'space' : event.key;
     return (
-      key.name.toUpperCase() === char.toUpperCase() &&
+      key.name.toLowerCase() === pressedKey.toLowerCase() &&
       key.alt === event.altKey &&
       key.ctrl === event.ctrlKey &&
       key.meta === event.metaKey &&

--- a/packages/recoil-devtools-dock/test/DockMonitor.test.tsx
+++ b/packages/recoil-devtools-dock/test/DockMonitor.test.tsx
@@ -31,9 +31,10 @@ function Monitor({ label = 'Monitor' }: { label?: string }) {
 }
 
 function pressShortcut(key: string, ctrlKey = true, shiftKey = false) {
+  // Deliberately omits the deprecated `keyCode`/`which` init dict entries:
+  // shortcut matching must rely on `key` alone.
   return fireEvent.keyDown(window, {
     key,
-    keyCode: key.toUpperCase().charCodeAt(0),
     ctrlKey,
     shiftKey,
   });
@@ -221,6 +222,24 @@ describe('DockMonitor', () => {
     );
     expect(dock().hidden).toBe(false);
     expect(dock().dataset.position).toBe('right');
+  });
+
+  it('matches non-alphabetic shortcuts via event.key without keyCode', () => {
+    const { rerender } = render(
+      <DockMonitor toggleVisibilityKey="ctrl-enter" persistState={false}>
+        <Monitor />
+      </DockMonitor>
+    );
+    expect(dock().hidden).toBe(false);
+    fireEvent.keyDown(window, { key: 'Enter', ctrlKey: true });
+    expect(dock().hidden).toBe(true);
+    rerender(
+      <DockMonitor toggleVisibilityKey="ctrl-space" persistState={false}>
+        <Monitor />
+      </DockMonitor>
+    );
+    fireEvent.keyDown(window, { key: ' ', ctrlKey: true });
+    expect(dock().hidden).toBe(false);
   });
 
   it('removes its keyboard listener on unmount', () => {


### PR DESCRIPTION
Closes #150.

## What
Rewrites `matchesKey` in `DockMonitor` to compare the `parse-key` shortcut name against the modern `KeyboardEvent.key` value (case-insensitive, with a space-character alias) instead of the deprecated `keyCode`/`which` properties plus `String.fromCharCode`.

## Why
The legacy properties are deprecated and incorrect for non-alphabetic keys, so shortcuts such as `ctrl-enter` or `ctrl-space` never matched.

## Changes
- `packages/recoil-devtools-dock/src/DockMonitor.tsx`: `matchesKey` now uses `event.key`.
- `packages/recoil-devtools-dock/test/DockMonitor.test.tsx`: test helper no longer sends `keyCode` (matching must rely on `key` alone); new regression test covers `ctrl-enter` and `ctrl-space` without any `keyCode`.
- `.changeset/dock-monitor-event-key.md`: patch changeset for `recoil-devtools-dock`.

## Testing
- `pnpm vitest run` in `packages/recoil-devtools-dock`: 20/20 pass (baseline before the change: 19/19).
- New regression test verified to fail on the pre-fix implementation and pass with the fix.
- `pnpm typecheck` and `pnpm lint` clean.

---
*Automated maintenance by Muse Code (AI agent) acting for the repo owner. Reply here if anything looks wrong.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard shortcut detection in the dock monitor.
  * Shortcuts such as `Ctrl+Enter` and `Ctrl+Space` now work correctly across supported browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->